### PR TITLE
Adding run-cmd task

### DIFF
--- a/tasks/get-lease.yaml
+++ b/tasks/get-lease.yaml
@@ -35,7 +35,7 @@ spec:
 
          # Use the client name provided in the parameter
          echo "Using the client $(params.client-name)"
-         jmp client use-config $(params.client-name)
+         jmp client config use $(params.client-name)
 
          # Loop through each label provided as argument and build 
          #TODO: Once the lease timeout is implemented, add the $parameter.lease-duration to the command.

--- a/tasks/get-lease.yaml
+++ b/tasks/get-lease.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: jumpstarter-get-lease
-  namespace: jumpstarter-pipelines
 spec:
   params:
     - default: 'default'

--- a/tasks/get-lease.yaml
+++ b/tasks/get-lease.yaml
@@ -41,11 +41,11 @@ spec:
          CLIENT_LEASE_CMD="jmp client lease request"
          for label in "$@"; do
            IFS='=' read -r KEY VAL <<< "$label"
-           CLIENT_LEASE_CMD+=" -l $KEY $VAL"
+           CLIENT_LEASE_CMD+=" -l $KEY=$VAL"
          done
 
          # Request a lease
-         JMP_LEASE_ID=$(timeout "$(params.timeout)" $CLIENT_LEASE_CMD)
+         JMP_LEASE_ID=$(timeout "$(params.timeout)" $CLIENT_LEASE_CMD -o name) 
 
          # Output the lease ID to the Tekton results
          echo -n "$JMP_LEASE_ID" > /tekton/results/jmp-lease-id

--- a/tasks/release-lease.yaml
+++ b/tasks/release-lease.yaml
@@ -24,7 +24,7 @@ spec:
          export JMP_LEASE_ID=$(params.jmp-lease-id)
 
          # Switch to the specified Jumpstarter client configuration
-         jmp client use-config "$(params.client-name)"
+         jmp client config use "$(params.client-name)"
          echo "Using Jumpstarter client configuration: $(params.client-name)"
 
          # Release the lease associated with the provided lease ID

--- a/tasks/release-lease.yaml
+++ b/tasks/release-lease.yaml
@@ -2,7 +2,6 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: jumpstarter-release-lease
-  namespace: jumpstarter-pipelines
 spec:
   params:
     - description: The lease to be released.

--- a/tasks/run-cmd.yaml
+++ b/tasks/run-cmd.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: jumpstarter-run-command
+spec:
+  params:
+    - description: The lease ID to use for command execution.
+      name: jmp-lease-id
+      type: string
+    - default: 'default'
+      description: The client config to use.
+      name: client-name
+      type: string
+    - description: The commands to run.
+      name: jmp-jScript
+      type: string
+    
+  steps:
+    - computeResources: {}
+      image: 'quay.io/jumpstarter-dev/jumpstarter:latest'
+      name: jmp-run-command
+      script: |
+        #!/bin/bash
+        set -eux
+
+        # Use to the specified Jumpstarter client configuration
+        jmp client config use "$(params.client-name)"
+        echo "Using Jumpstarter client configuration: $(params.client-name)"
+
+        # Set the Jumpstarter lease environment variable
+        export JMP_LEASE="$(params.jmp-lease-id)"
+
+        # Show the command that will be executed
+        echo "Running: $(params.jmp-jScript)"
+
+        cd /workspace/source
+        ls -la
+
+        # Execute the script commands within the Jumpstarter shell
+        jmp client shell <<-EOF
+          $(params.jmp-jScript)
+        EOF
+
+        echo "The jScript commands were successfully executed."
+  workspaces:
+    - description: Workspace for mounting Jumpstarter client files.
+      mountPath: /root/.config/jumpstarter/clients
+      name: jumpstarter-client-secret
+      readOnly: true
+    - description: Workspace containing the source code / build images
+      name: source


### PR DESCRIPTION
This PR uses the new jmp client to execute various Tekton tasks and adds a new general task to run jScript commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the `namespace` field from lease management tasks and updated client configuration commands for improved clarity.
- **New Features**
  - Introduced a new task for executing commands with custom parameters in a containerized environment, enhancing operational flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->