### PR TITLE
Improve flexibility to allow running different images

### DIFF
--- a/tasks/run-cmd.yaml
+++ b/tasks/run-cmd.yaml
@@ -14,10 +14,17 @@ spec:
     - description: The commands to run.
       name: jmp-jScript
       type: string
-    
+    - description: Image to use.
+      name: image
+      type: string
+      default: 'quay.io/jumpstarter-dev/jumpstarter:latest'
+    - description: User home for the provided image
+      name: home
+      type: string
+      default: '/root'
   steps:
     - computeResources: {}
-      image: 'quay.io/jumpstarter-dev/jumpstarter:latest'
+      image: "$(params.image)"
       name: jmp-run-command
       script: |
         #!/bin/bash
@@ -44,7 +51,7 @@ spec:
         echo "The jScript commands were successfully executed."
   workspaces:
     - description: Workspace for mounting Jumpstarter client files.
-      mountPath: /root/.config/jumpstarter/clients
+      mountPath: "$(params.home)/.config/jumpstarter/clients"
       name: jumpstarter-client-secret
       readOnly: true
     - description: Workspace containing the source code / build images


### PR DESCRIPTION
For example, the image could contain different python tools, like pytest, etc...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved task configuration by allowing you to dynamically set the Docker image and user home directory, offering greater flexibility during task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->