### PR TITLE
Don't do ls during run, as it polutes log output

### DIFF
--- a/tasks/run-cmd.yaml
+++ b/tasks/run-cmd.yaml
@@ -34,7 +34,6 @@ spec:
         echo "Running: $(params.jmp-jScript)"
 
         cd /workspace/source
-        ls -la
 
         # Execute the script commands within the Jumpstarter shell
         jmp shell --lease "${params.jmp-lease-id}" <<-EOF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an internal command that listed directory contents during execution to streamline the process.
	- Enhanced file formatting to ensure proper file termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->