### PR TITLE
Add client config option to the tekton tasks

### DIFF
--- a/tasks/get-lease.yaml
+++ b/tasks/get-lease.yaml
@@ -19,6 +19,10 @@ spec:
       description: Maximum time (in HH:MM:SS format) for holding lease before relasing it.
       name: lease-duration
       type: string
+    - name: 'client-config'
+      description: Jumpstarter client config contents, can be used instead of the workspace.
+      type: string
+      default: ''
   results:
     - description: The Lease ID from Jumpstarter
       name: jmp-lease-id
@@ -31,6 +35,26 @@ spec:
       script: |
         #!/usr/bin/env bash
          set -eux
+
+         # If the client-config parameter is provided, create and use a new client config.
+         if [ -n "$(params.client-config)" ]; then
+          set +x
+
+          CONFIG_DIR="/root/.config/jumpstarter/clients"
+          CONFIG_FILE="$CONFIG_DIR/default.yaml"
+          POD_TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+          CONFIG_CONTENT="$(params.client-config)"
+
+          # Create the config directory if it doesn't exist and write the config content to a file
+          mkdir -p "$CONFIG_DIR"
+          echo "$CONFIG_CONTENT" > "$CONFIG_FILE"
+
+          # Replace the __POD_TOKEN__ placeholder with the actual pod token
+          POD_TOKEN=$(cat "$POD_TOKEN_FILE")
+          sed -i "s/__POD_TOKEN__/$POD_TOKEN/g" "$CONFIG_FILE"
+          
+          set -x
+         fi
 
          # Use the client name provided in the parameter
          echo "Using the client $(params.client-name)"
@@ -53,4 +77,4 @@ spec:
     - description: Workspace for mounting Jumpstarter client files.
       mountPath: /root/.config/jumpstarter/clients
       name: jumpstarter-client-secret
-      readOnly: true
+      

--- a/tasks/release-lease.yaml
+++ b/tasks/release-lease.yaml
@@ -11,6 +11,10 @@ spec:
       description: The client intending to release the lease.
       name: client-name
       type: string
+    - name: 'client-config'
+      description: Jumpstarter client config contents, can be used instead of the workspace.
+      type: string
+      default: ''
   steps:
     - computeResources: {}
       image: 'quay.io/jumpstarter-dev/jumpstarter:latest'
@@ -18,6 +22,27 @@ spec:
       script: |
         #!/bin/bash
           set -eux
+
+         # If the client-config parameter is provided, create and use a new client config.
+         if [ -n "$(params.client-config)" ]; then
+          # Disable logging to avoid leaking sensitive data.
+          set +x
+
+          CONFIG_DIR="/root/.config/jumpstarter/clients"
+          CONFIG_FILE="$CONFIG_DIR/default.yaml"
+          POD_TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+          CONFIG_CONTENT="$(params.client-config)"
+
+          # Create the config directory if it doesn't exist and write the config content to a file
+          mkdir -p "$CONFIG_DIR"
+          echo "$CONFIG_CONTENT" > "$CONFIG_FILE"
+
+          # Replace the __POD_TOKEN__ placeholder with the actual pod token
+          POD_TOKEN=$(cat "$POD_TOKEN_FILE")
+          sed -i "s/__POD_TOKEN__/$POD_TOKEN/g" "$CONFIG_FILE"
+          
+          set -x
+         fi
 
          # Set the lease ID from the pipeline parameter into the environment variable
          export JMP_LEASE_ID=$(params.jmp-lease-id)
@@ -35,3 +60,4 @@ spec:
   workspaces:
     - mountPath: /root/.config/jumpstarter/clients
       name: jumpstarter-client-secret
+      

--- a/tasks/run-cmd.yaml
+++ b/tasks/run-cmd.yaml
@@ -22,6 +22,10 @@ spec:
       name: home
       type: string
       default: '/root'
+    - name: 'client-config'
+      description: Jumpstarter client config contents, can be used instead of the workspace.
+      type: string
+      default: ''
   steps:
     - computeResources: {}
       image: "$(params.image)"
@@ -29,6 +33,27 @@ spec:
       script: |
         #!/bin/bash
         set -eux
+
+         # If the client-config parameter is provided, create and use a new client config.
+         if [ -n "$(params.client-config)" ]; then
+          # Disable logging to avoid leaking sensitive data.
+          set +x
+
+          CONFIG_DIR="$(params.home)/.config/jumpstarter/clients"
+          CONFIG_FILE="$CONFIG_DIR/default.yaml"
+          POD_TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+          CONFIG_CONTENT="$(params.client-config)"
+
+          # Create the config directory if it doesn't exist and write the config content to a file
+          mkdir -p "$CONFIG_DIR"
+          echo "$CONFIG_CONTENT" > "$CONFIG_FILE"
+
+          # Replace the __POD_TOKEN__ placeholder with the actual pod token
+          POD_TOKEN=$(cat "$POD_TOKEN_FILE")
+          sed -i "s/__POD_TOKEN__/$POD_TOKEN/g" "$CONFIG_FILE"
+          
+          set -x
+         fi
 
         # Use to the specified Jumpstarter client configuration
         jmp config client use "$(params.client-name)"
@@ -52,6 +77,5 @@ spec:
     - description: Workspace for mounting Jumpstarter client files.
       mountPath: "$(params.home)/.config/jumpstarter/clients"
       name: jumpstarter-client-secret
-      readOnly: true
     - description: Workspace containing the source code / build images
       name: source


### PR DESCRIPTION
Based on changes from https://github.com/rhadp-example-repos/lab2255-templates.

Previously, the user was required to provide a Kubernetes Secret containing the Jumpstarter ClientConfig. With this task, the config is generated dynamically using task parameters, including a placeholder for the Kubernetes ServiceAccount token (__POD_TOKEN__). This allows Jumpstarter to authenticate the client based on the pod's ServiceAccount, without requiring a pre-existing secret. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an optional parameter to allow users to provide Jumpstarter client configuration directly as a string for lease and command tasks.

- **Improvements**
  - Tasks can now run without requiring a mounted workspace for Jumpstarter client files, increasing flexibility in configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->