### PR TITLE
Add task to generate Jumpstarter client config from pod service account

### DIFF
--- a/tasks/setup-sa- client.yaml
+++ b/tasks/setup-sa- client.yaml
@@ -1,0 +1,61 @@
+kind: Task
+apiVersion: tekton.dev/v1beta1
+metadata:
+  name: jumpstarter-setup-sa-client
+spec:
+  description: |
+    Create Jumpstarter client config from the user system account in Kubernetes,
+    this requires that Jumpstarter is configured to trust authentication from K8s
+  params:
+    - name: endpoint
+      description: "The Jumpstarter grpc endpoint"
+      type: string
+    - name: namespace
+      description: "The Jumpstarter client namespace"
+      type: string
+    - name: name
+      description: "The Jumpstarter client name"
+      type: string
+    - name: insecure-tls
+      description: "Use insecure tls for grpc"
+      type: string
+      default: "false"
+    - name: tls-ca
+      description: "CA Cert for the TLS endpoint"
+      type: string
+      default: ""
+
+  results:
+    - name: config
+      description: "The content of the generated Jumpstarter client config file"
+
+  steps:
+    - name: setup-client
+      image: quay.io/fedora/fedora-minimal:43
+      script: |
+        #!/usr/bin/env bash
+
+        CONFIG_DIR=$(workspaces.config-dir.path)
+
+        # generate jumpstarter client config
++       cat <<-EOF > "${CONFIG_DIR}/default.yaml"
+        apiVersion: jumpstarter.dev/v1alpha1
+        kind: ClientConfig
+        metadata:
+          namespace: $(params.namespace)
+          name: $(params.name)
+        endpoint: $(params.endpoint)
+        tls:
+          insecure: $(params.insecure-tls)
+          ca: \"$(params.tls-ca)\"
+        token: __POD_TOKEN__
+
+        drivers:
+          allow: []
+          unsafe: True
+        EOF
+
+        cp ${CONFIG_DIR}/default.yaml $(results.config.path)
+  workspaces:
+    - name: config-dir
+      description: The workspace which contains Jumpstarter client config file


### PR DESCRIPTION
Taken from https://github.com/rhadp-example-repos/lab2255-templates/blob/main/templates/autosd-app-template/skeleton/.tekton/tasks/jumpstarter-setup-sa-client.yaml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new task for generating a Jumpstarter client configuration file with customizable parameters, including endpoint, namespace, name, and TLS settings. The generated configuration can be used in downstream processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->